### PR TITLE
Use single threaded event delivery to avoid incorrect ordering.

### DIFF
--- a/src/main/java/xyz/cp74/evdev/InputDevice.java
+++ b/src/main/java/xyz/cp74/evdev/InputDevice.java
@@ -52,6 +52,7 @@ public class InputDevice implements InputDevicePath  {
     private int maxConnectionAttemps = 10;
     
     // thread pool
+    private final ExecutorService globalExecutor = Executors.newSingleThreadExecutor();
     ExecutorService threadPool = Executors.newCachedThreadPool();
     
 	// listeners
@@ -259,7 +260,7 @@ public class InputDevice implements InputDevicePath  {
 	                    e.value = buffer.getInt();
 	                    // send event to listeners
                         if (globalListener!=null) 
-                            threadPool.execute(()->globalListener.onEvent(e));
+                            globalExecutor.execute(()->globalListener.onEvent(e));
 		                if (eventListeners.containsKey(e.getTypeCode()))
 			                threadPool.execute(()->eventListeners.get(e.getTypeCode()).onEvent(e));
                     }


### PR DESCRIPTION
Resolve a problem where events were delivered in the wrong order by making globalListener use single-threaded delivery. The JVM does not make guarantees about the order that threads run in and under heavy load this leads to events being delivered to listeners in a different order to that in what they arrived.